### PR TITLE
fix: add @input to sw-text-field with enable validation

### DIFF
--- a/src/Resources/app/administration/src/module/swag-paypal/components/swag-paypal-credentials/swag-paypal-credentials.html.twig
+++ b/src/Resources/app/administration/src/module/swag-paypal/components/swag-paypal-credentials/swag-paypal-credentials.html.twig
@@ -20,7 +20,8 @@
                                                    :disabled="props.isInherited || !acl.can('swag_paypal.editor')"
                                                    :value="props.currentValue"
                                                    :error="clientIdErrorState"
-                                                   @change="props.updateCurrentValue">
+                                                   @change="props.updateCurrentValue"
+                                                   @input="props.updateCurrentValue">
                                     </sw-text-field>
                                 </template>
                             </sw-inherit-wrapper>
@@ -38,7 +39,8 @@
                                                    :disabled="props.isInherited || !acl.can('swag_paypal.editor')"
                                                    :value="props.currentValue"
                                                    :error="clientSecretErrorState"
-                                                   @change="props.updateCurrentValue">
+                                                   @change="props.updateCurrentValue"
+                                                   @input="props.updateCurrentValue">
                                     </sw-text-field>
                                 </template>
                             </sw-inherit-wrapper>
@@ -100,7 +102,8 @@
                                                    :disabled="props.isInherited || !acl.can('swag_paypal.editor')"
                                                    :value="props.currentValue"
                                                    :error="clientIdSandboxErrorState"
-                                                   @change="props.updateCurrentValue">
+                                                   @change="props.updateCurrentValue"
+                                                   @input="props.updateCurrentValue">
                                     </sw-text-field>
                                 </template>
                             </sw-inherit-wrapper>
@@ -118,7 +121,8 @@
                                                    :disabled="props.isInherited || !acl.can('swag_paypal.editor')"
                                                    :value="props.currentValue"
                                                    :error="clientSecretSandboxErrorState"
-                                                   @change="props.updateCurrentValue">
+                                                   @change="props.updateCurrentValue"
+                                                   @input="props.updateCurrentValue">
                                     </sw-text-field>
                                 </template>
                             </sw-inherit-wrapper>


### PR DESCRIPTION
Adding @input to sw-text-field does a better UX for fields in the plugin configuration that are required and have validation added.

With this change, you don't need to remove :focus from input to see the error message.